### PR TITLE
Fix idle timer reassignment bug

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -1370,7 +1370,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         isFadingToIdle = false;
 
-        const currentIdleTimeoutSeconds = parseInt(settings.idleTimeoutSeconds, 10) || DEFAULT_SETTINGS.idleTimeoutSeconds;
+        let currentIdleTimeoutSeconds = parseInt(settings.idleTimeoutSeconds, 10) || DEFAULT_SETTINGS.idleTimeoutSeconds;
         let currentFadeOutLeadSeconds = parseInt(settings.fadeOutLeadTimeSeconds, 10) || DEFAULT_SETTINGS.fadeOutLeadTimeSeconds;
 
         if (currentFadeOutLeadSeconds >= currentIdleTimeoutSeconds) {


### PR DESCRIPTION
## Summary
- fix bug where `currentIdleTimeoutSeconds` was a `const` but reassigned

## Testing
- `node --check quiz.js`


------
https://chatgpt.com/codex/tasks/task_e_6841aa7c8f388322bbf6ca911fc6e66d